### PR TITLE
Fix importing error in c_ast_to_minic

### DIFF
--- a/minic/c_ast_to_minic.py
+++ b/minic/c_ast_to_minic.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from pycparser import c_ast, parse_file
-import minic.minic_ast as mc
-from minic.mutils import lmap
+import minic_ast as mc
+from mutils import lmap
 
 
 # In the transformation process, all the nodes will receive an id for


### PR DESCRIPTION
When importing and using c_ast_to_minic.py an error would be thrown because of the "minic." prefix on the imports.

They shouldn't be needed as all of the minic files are in one folder.